### PR TITLE
Repair mybinder

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -7,3 +7,11 @@ numpy
 pandas
 plotly
 PyDynamic
+# This was needed from 3e072fd on, because of the following error in the cached
+# mybinder.org image while installing dependencies:
+# Attempting uninstall: terminado
+#     Found existing installation: terminado 0.8.3
+# ERROR: Cannot uninstall 'terminado'. It is a distutils installed project and thus we
+# cannot accurately determine which files belong to it which would lead to only a
+# partial uninstall.
+terminado == 0.8.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -51,7 +51,7 @@ parso==0.7.1              # via jedi
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pillow==7.2.0             # via bokeh, matplotlib
-plotly==4.10.0            # via -r requirements/requirements.in
+plotly==4.11.0            # via -r requirements/requirements.in
 prometheus-client==0.8.0  # via notebook
 prompt-toolkit==3.0.7     # via ipython
 ptyprocess==0.6.0         # via pexpect, terminado
@@ -71,7 +71,7 @@ retrying==1.3.3           # via plotly
 scipy==1.5.2              # via pydynamic
 send2trash==1.5.0         # via notebook
 six==1.15.0               # via argon2-cffi, bleach, cycler, download, h5py, jsonschema, packaging, plotly, python-dateutil, retrying
-terminado==0.9.1          # via notebook
+terminado==0.8.3          # via -r requirements/requirements.in, notebook
 testpath==0.4.4           # via nbconvert
 tornado==6.0.4            # via bokeh, ipykernel, jupyter-client, notebook, terminado
 tqdm==4.50.0              # via download, panel


### PR DESCRIPTION
Due to an error on image creation on mybinder.org, we had to pin `terminado == 0.8.3`.